### PR TITLE
Fixed warning and added stable tag

### DIFF
--- a/admin/class-gridable-admin.php
+++ b/admin/class-gridable-admin.php
@@ -135,13 +135,15 @@ class Gridable_Admin {
 	}
 
 	public function change_tinymce_settings( $settings ) {
-		if ( empty( $settings['tinymce'] ) ) {
-			$settings['tinymce'] = array();
+		if ( false !== $settings['tinymce'] ) {
+			if ( ! is_array( $settings['tinymce'] ) ) {
+				$settings['tinymce'] = array();
+			}
+			// We need to disable keeping the scroll position when switching between Visual and Text mode
+			// due to the fact that this functionality relies on some inline spans that get autop'd
+			// and result in certain cases in &nbsp; characters. Making a solid Regex for this is very tricky.
+			$settings['tinymce']['wp_keep_scroll_position'] = false;
 		}
-		// We need to disable keeping the scroll position when switching between Visual and Text mode
-		// due to the fact that this functionality relies on some inline spans that get autop'd
-		// and result in certain cases in &nbsp; characters. Making a solid Regex for this is very tricky.
-		$settings['tinymce']['wp_keep_scroll_position'] = false;
 
 		return $settings;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pixelgrade, vlad.olaru, euthelup, babbardel, razvanonofrei,
 Tags: grid, preview, render, row, column, inline-edit
 Requires at least: 4.7.0
-Tested up to: 5.0
+Tested up to: 5.0.2
 Stable tag: 1.2.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: pixelgrade, vlad.olaru, euthelup, babbardel, razvanonofrei,
 Tags: grid, preview, render, row, column, inline-edit
 Requires at least: 4.7.0
-Tested up to: 4.9.8
-Stable tag: 1.2.5
+Tested up to: 5.0
+Stable tag: 1.2.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Fix for the warnings that appeared in the Dashboard, when we tried to create a new post in the Gutenberg editor.

Modified the stable tag.