### PR TITLE
Fix Gutenberg detection

### DIFF
--- a/includes/class-gridable.php
+++ b/includes/class-gridable.php
@@ -133,22 +133,42 @@ class Gridable {
 	 * @return bool
 	 */
 	protected function is_gutenberg_active() {
+	// Gutenberg plugin is installed and activated.
+	    $gutenberg = !(false === has_filter('replace_editor', 'gutenberg_init'));
 
-		include_once ABSPATH . 'wp-admin/includes/plugin.php';
+	    // Block editor since 5.0.
+	    $block_editor = version_compare($GLOBALS['wp_version'], '5.0-beta', '>');
 
-		if ( is_plugin_active( 'classic-editor/classic-editor.php' ) ||
-		     is_plugin_active( 'disable-gutenberg/disable-gutenberg.php' ) ) {
-			return false;
-		}
+	    if (!$gutenberg && !$block_editor) {
+	      return false;
+	    }
 
-		// Check version and if Gutenberg is installed and activated.
-		if ( version_compare( $GLOBALS['wp_version'], '5.0-beta', '>' ) ) {
-			return true;
-		}
+	    if ($this->is_classic_editor_plugin_active()) {
+	      $editor_option       = get_option('classic-editor-replace');
+	      $block_editor_active = array('no-replace', 'block');
 
-		$use_block_editor = ( get_option( 'classic-editor-replace' ) === 'no-replace' );
+	      return in_array($editor_option, $block_editor_active, true);
+	    }
 
-		return $use_block_editor;
+	    return true;
+	  }
+
+	  /**
+	   * Check if Classic Editor plugin is active.
+	   *
+	   * @return bool
+	   */
+	  function is_classic_editor_plugin_active()
+	  {
+	    if (!function_exists('is_plugin_active')) {
+	      include_once ABSPATH . 'wp-admin/includes/plugin.php';
+	    }
+
+	    if (is_plugin_active('classic-editor/classic-editor.php')) {
+	      return true;
+	    }
+
+	    return false;
 	}
 
 	/**


### PR DESCRIPTION
Hi and thank you for this plugin. This PR fixes the detection of Gutenberg according to https://wordpress.stackexchange.com/questions/320653/how-to-detect-the-usage-of-gutenberg – please note that this is only a partial fix for the Gutenberg compatibility, since this way, the shortcodes are in text form in the Gutenberg editor. But, at least, the editor does not freeze by default as was the case for me before this change.